### PR TITLE
Fix Bower Error

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "coffee-script": "1.3.3",
     "underscore": "~1.4.4",
     "q": "~0.8.12",
-    "bower": "~0.7.0"
+    "bower": "~0.8.5"
   },
   "devDependencies": {
     "mocha": "1.2.2",


### PR DESCRIPTION
Bower throws this error whenever `bower` is called:

```
path.js:360
        throw new TypeError('Arguments to path.join must be strings');
```

They had the same problem in yeoman, which was fixed here: https://github.com/yeoman/generator/commit/c8188b4cb3c63db6298394328dfffda4dada247f
