### PR TITLE
Bump Bower to 0.9.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "coffee-script": "1.3.3",
     "underscore": "~1.4.4",
     "q": "~0.8.12",
-    "bower": "~0.8.5"
+    "bower": "~0.9.2"
   },
   "devDependencies": {
     "mocha": "1.2.2",


### PR DESCRIPTION
Bower has deprecated `component.json` in favor of `bower.json`
