### PR TITLE
Bump bower dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "coffee-script": "1.3.3",
     "underscore": "~1.4.4",
     "q": "~0.8.12",
-    "bower": "~0.8.5"
+    "bower": "~0.9.2"
   },
   "devDependencies": {
     "mocha": "1.2.2",


### PR DESCRIPTION
bower has jumped to version 0.9.x which breaks compatibility with former component.json (now bower.json)
